### PR TITLE
Ensure HDZ name renders as expected, not as unsafeHTML tag.

### DIFF
--- a/layouts/publications/list.html
+++ b/layouts/publications/list.html
@@ -38,7 +38,7 @@
 	    <p>
 	      {{ if .Params.paperURL }}
 	      <a href="{{ .Params.paperURL }}">
-	      {{ delimit $authors ", " ", & " }}
+	      {{ delimit $authors ", " ", & " | safeHTML }}
 	      ({{ .Params.year }}). {{ .Params.summary | safeHTML }}
 	      {{ if .Params.doi }}doi: {{ .Params.doi }}{{ end }}
 	      </a>


### PR DESCRIPTION
Before this change:

<img width="773" alt="Screenshot 2024-05-23 at 12 54 19" src="https://github.com/hallez/hrz-website/assets/7230694/0fbae992-76aa-4451-ab86-f7cdb3adf98f">

After this change:

<img width="776" alt="Screenshot 2024-05-23 at 12 54 43" src="https://github.com/hallez/hrz-website/assets/7230694/0be6726e-6448-4045-afb4-68428de4e4f2">

This was previously working, so my guess is a more recent version of hugo identified the lack of `safeHTML` as a bug.